### PR TITLE
fix small typo in German translation and module name

### DIFF
--- a/src/lang-german.tex
+++ b/src/lang-german.tex
@@ -64,7 +64,7 @@
 \newcommand{\LANGZoomBetweenOneOneAndFitToScreen}{Ansicht von 1:1 bis einpassen}
 \newcommand{\LANGZoomBetweenTwoOneAndOneOneZero}{Ansicht von 2:1 bis 1:10}
 \newcommand{\LANGExpandModuleKeepPreviousExpanded}{Modul öffnen, vorheriges offen lassen}
-\newcommand{\LANGSetValue}{Wert sezten}
+\newcommand{\LANGSetValue}{Wert setzen}
 \newcommand{\LANGPopUpForMouseControlOrDirectValueEnter}{Eingabe durch Mausgeste oder Tastatur}
 \newcommand{\LANGResetToDefault}{Zurück auf Standardwert}
 \newcommand{\LANGContrastBrightnessSaturation}{Kontrast Helligkeit Sättigung}
@@ -94,7 +94,7 @@
 \newcommand{\LANGColorBalance}{Farbbalance}
 \newcommand{\LANGVibrance}{Lebendigkeit}
 \newcommand{\LANGInputColorProfile}{Eingabefarbprofil}
-\newcommand{\LANGUnbreakInputProfile}{Eingabefarbprofil korrigieren}
+\newcommand{\LANGUnbreakInputProfile}{Eingabeprofil korrigieren}
 \newcommand{\LANGDithering}{Dithering}
 \newcommand{\LANGSharpen}{Schärfen}
 \newcommand{\LANGEqualizer}{Equalizer}


### PR DESCRIPTION
Hi,

The module name in version 2.0 is 'Eingabeprofil korrigieren'. I did not checked 1.6.x, but maybe this has been changed. 

The refcard does not contain a version string for which the shortcuts are valid. e.g. 'Ctrl+z' has been remove. There will only be 'z' in the upcoming version 2.0.

What's you plan for the release? I like to post a link to your refcard on a German forum. I don't want do that before your 'official' release.

Christian
